### PR TITLE
Refactor: Skip background image filters in dark mode

### DIFF
--- a/content-add-style.js
+++ b/content-add-style.js
@@ -49,6 +49,9 @@
    * Find all elements with background-image style and apply CSS filter
    */
   function applyBackgroundImageFilters() {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return;
+    }
     // Find elements with inline background-image styles
     const elementsWithBgImage = document.querySelectorAll('*');
 


### PR DESCRIPTION
The `applyBackgroundImageFilters` function will now return immediately if the browser is in dark mode. This prevents unintended filter applications on sites that already have a dark theme.