### PR TITLE
Fix: Ensure release-on-tag workflow triggers

### DIFF
--- a/.github/workflows/version-and-tag.yml
+++ b/.github/workflows/version-and-tag.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          npm version patch -m "chore(release): %s [skip ci]"
+          npm version patch -m "chore(release): %s"
           git push origin main --follow-tags


### PR DESCRIPTION
The `release-on-tag.yml` workflow was not being triggered when new tags were pushed by the `version-and-tag.yml` workflow.

This was likely due to the `npm version` command in `version-and-tag.yml` creating a commit with `[skip ci]` in its message. When this commit and its associated tag were pushed simultaneously, the `[skip ci]` directive might have caused GitHub Actions to skip all workflows for that push event, including the tag-triggered release workflow.

This commit removes `[skip ci]` from the commit message generated by `npm version` in the `version-and-tag.yml` workflow. This should allow the `release-on-tag.yml` workflow to trigger as expected when new tags are pushed.